### PR TITLE
Fix variable name on gpsd.toml

### DIFF
--- a/gpsd.toml
+++ b/gpsd.toml
@@ -1,3 +1,3 @@
 main.plugins.gpsd.enabled = true
 main.plugins.gpsd.gpsdhost = "127.0.0.1"
-main.plugins.gpsd.port = 2947
+main.plugins.gpsd.gpsdport = 2947


### PR DESCRIPTION
Just a fix to the variable name port, to gpsdport.
Cause on gpsd.py, the script tried to get xxx.gpsdhost and xxx.gpsdport.
I made this change, and it works like a charm on my RPI